### PR TITLE
Fix roulette function when eth.link is down.

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -330,9 +330,9 @@ export default function Header() {
           <StyledNavLink id={`about-nav-link`} to={'/about'}>
           About
           </StyledNavLink>
-          <StyledMenuButton onClick={() => window.location.assign('https://penguinswap.eth.link/#/swap?outputCurrency=0x30bcd71b8d21fe830e493b30e90befba29de9114')}>
+          <StyledNavLink id={`roulette-nav-link`} to={'/swap?outputCurrency=0x30bcd71b8d21fe830e493b30e90befba29de9114'}>
           Roulette
-          </StyledMenuButton>
+          </StyledNavLink>
         </HeaderLinks>
       </HeaderRow>
       <HeaderControls>


### PR DESCRIPTION
The "Roulette" button doesn't work if you are on the IPFS link when the .eth.link is down because the button sends you to the .eth.link website. This is fixed and the button style is also now consistent since I changed the StyledMenuButton into a StyledNavLink.