### PR TITLE
Update broken uniswap.info link to penguinalytics

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -290,7 +290,7 @@ export default function FullPositionCard({ pair, border }: PositionCardProps) {
             <ButtonSecondary padding="8px" borderRadius="8px">
               <ExternalLink
                 style={{ width: '100%', textAlign: 'center' }}
-                href={`https://uniswap.info/account/${account}`}
+                href={`https://penguinalytics.eth.link/#/account/${account}`}
               >
                 View accrued fees and analytics<span style={{ fontSize: '11px' }}>↗</span>
               </ExternalLink>


### PR DESCRIPTION
The link in the screenshot below was pointing to the old uniswap info URL which stopped working with the release of uniswap v3. This commit changes the link to redirect to the new penguinaltyics link.

<img width="820" alt="Screen Shot 2021-07-07 at 9 27 42 PM" src="https://user-images.githubusercontent.com/13601394/124848214-67723f00-df6a-11eb-972b-db7d84cf9110.png">
